### PR TITLE
Mention explicit option for executable path

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ https://github.com/ddollar/heroku-buildpack-multi). For example, to add Graphviz
 
 This incorporates the `graphviz` Debian package in your application release.
 
+In case your app requires an explicit excutable path, you can do so by (e.g. for `dot`):
+`heroku config:set GRAPHVIZ_DOT=/app/vendor/graphviz/usr/bin/dot`
 
 Relation with heroku-buildpack-graphviz-src
 -------------------------------------------


### PR DESCRIPTION
Thanks very much for the buildpack! 
 Only in my  case the binaries weren't picked up automatically so I had to set the executable path explicit. It took me a bit to figure out the correct path, so I thought I'd nice to mention this in the README. Thanks!
